### PR TITLE
support standalone apps

### DIFF
--- a/lib/apps.js
+++ b/lib/apps.js
@@ -1,0 +1,59 @@
+var flatten = require('component-resolver').flatten;
+var log = require('debug')('bundler:app:log');
+
+/**
+ * Creates bundles in the form of:
+ *
+ *    |-- bundle-a
+ *    |
+ *    |-- bundle-b
+ *    |
+ *    |-- bundle-c
+ *    |
+ *    |
+ *
+ * Each `bundle-x` are expected to be distinct pages.
+ * Your script tags should look like:
+ *
+ *   <script src="bundle-a.js"></script>
+ *
+ */
+
+module.exports = function (json) {
+  if (!json) {
+    throw new TypeError('locals required.');
+  }
+  var bundles = Array.isArray(json)
+    ? json
+    : json.locals;
+
+  // no bundles to build. exit silently
+  if (!bundles || bundles.length < 2) return {};
+
+  // copy
+  bundles = bundles.slice();
+
+  return function bundleApps(tree) {
+    var locals = tree.locals;
+
+    log(locals);
+
+    var out = {};
+
+    bundles.forEach(function (name) {
+      var bundleLocals = flatten(locals[name]);
+
+      // copy
+      bundleLocals = bundleLocals.slice();
+
+      bundleLocals.forEach(function (local) {
+        local.bundle = name;
+      });
+      // each standalone app contains its own dependencies
+      out[name] = bundleLocals;
+    });
+
+
+    return out;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "url": "https://github.com/component/bundler.js/issues"
   },
   "dependencies": {
-    "to-camel-case": "~0.2.0",
-    "component-resolver": "~0.0.0"
+    "component-resolver": "~0.0.0",
+    "debug": "^2.1.3",
+    "to-camel-case": "~0.2.0"
   }
 }


### PR DESCRIPTION
The example usage for `bundler.apps()` is on the [`standalone/example`](https://github.com/componentjs/bundler-example/tree/standalone/example) of `bundler-example`
